### PR TITLE
Update `laravel/prompts` version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "illuminate/http": "^10.0|^11.0.6",
         "illuminate/queue": "^10.0|^11.0.6",
         "illuminate/routing": "^10.0|^11.0.6",
-        "laravel/prompts": "^0.1.16",
+        "laravel/prompts": ">=0.1.16 <1.0.0",
         "spatie/laravel-package-tools": "^1.14.1"
     },
     "require-dev": {


### PR DESCRIPTION
This allows compatibility with versions from `0.1.16` to `<1.0.0`.

Laravel 11 currently uses the `^0.3` version, which is causing issues when requiring `laravel-wave` in new projects.

```bash
    - qruto/laravel-wave[0.9.0, ..., 0.9.1] require laravel/prompts ^0.1.16 -> found laravel/prompts[v0.1.16, ..., v0.1.25] but the package is fixed to v0.3.2 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```